### PR TITLE
chore(security): harden CI/CD posture and implement fuzzing

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,8 +8,7 @@ on:
   schedule:
     - cron: '21 16 * * 1'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   analyze:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,8 +2,7 @@ name: Run tests and upload coverage
 
 on: [push]
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   ACT: false
@@ -12,6 +11,8 @@ jobs:
   test:
     name: Run tests and collect coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: Scorecard supply-chain security
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '20 7 * * 2'
+  push:
+    branches: [ "main" ]
+
+permissions: {}
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@dc50aa9510b46c811795eb24b2f1ba02a914e534 # v2.3.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          publish_results: true
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -6,8 +6,7 @@ on:
   pull_request:
     branches: [ main ]
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   ACT: false

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -6,14 +6,15 @@ on:
   pull_request:
     branches: [ main ]
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
   golangci:
     name: Static Code Analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/delegate/delegate_fuzz_test.go
+++ b/delegate/delegate_fuzz_test.go
@@ -1,0 +1,21 @@
+package delegate
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+)
+
+func FuzzServerInfoUnmarshal(f *testing.F) {
+	f.Add([]byte("test server info"))
+	f.Add(make([]byte, DefaultServerInfoMaxLength+1))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		reader := bufio.NewReader(bytes.NewReader(data))
+		_, _, err := ServerInfoValidMUS.Unmarshal(reader)
+		if err != nil {
+			// Expected errors are fine, we just want to ensure no panics.
+			return
+		}
+	})
+}


### PR DESCRIPTION
- Implement OpenSSF Scorecard workflow for automated security auditing.
- Enforce granular, job-level permissions across all CI/CD workflows.
- Add fuzz testing for ServerInfo handshake payloads in the delegate package.